### PR TITLE
Creating default directory in case it's not attached at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Pawel Niemiec <pniemiec@noledgetech.com>
 
 RUN apt-get update && apt-get install -y tcpdump
 
+RUN mkdir /out && touch /out/file.pcap
+
 COPY ./src/entrypoint.sh /src/entrypoint.sh
 
 RUN chmod +x /src/entrypoint.sh


### PR DESCRIPTION
*What changes does this PR bring?*
Creating default directory in case it's not attached at runtime

*What are the relevant tickets?*
YEL-632

*Are tests included? (if applicable)*
Manual verification is possible. You can run the following commands:
```
# to start example docekr container
docker run -d ubuntu:xenial
# to obtain it's UBUNTU_ID
docker ps
# build this image
docker build -t dq-docker-netinspection .
# to start listening
docker run --net container:<UBUNTU_ID> dq-docker-netinspection
```
Before the last command was erroring out.
After this change you should got no errors.
You can then verify by running these commands
```
# Obtain UBUNTU_ID & NETINSPECT_ID
docker ps
# Generate some traffic
docker exec -ti <UBUNTU_ID> apt update
# Copy /out/file.pcap frm docker to local dir
docker cp <NETINSPECT_ID>:/out/file.pcap .
# Verify it is not empty
cat /out/file.pcap
```

*Types of review(s) required? (BE and/or FE)*
BE - Code review and manual verification
